### PR TITLE
In moodle 4.2 mod_form.php does not require version.php

### DIFF
--- a/mod_form.php
+++ b/mod_form.php
@@ -37,7 +37,6 @@ global $data, $cm, $CFG;
 
 require_once($CFG->dirroot . '/course/moodleform_mod.php');
 require_once($CFG->dirroot . '/mod/openmeetings/lib.php');
-require_once($CFG->dirroot . '/mod/openmeetings/version.php');
 
 $gateway = new OmGateway(get_om_config());
 $omlogin = $gateway->login();


### PR DESCRIPTION
In moodle 4.2 the mod_form.php does not require once => version.php